### PR TITLE
Removed logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,17 +35,6 @@
             <version>2.3</version>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.3.0-alpha4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.0-alpha0</version>

--- a/src/test/java/no/stelar7/api/l4j8/tests/cache/CacheTest.java
+++ b/src/test/java/no/stelar7/api/l4j8/tests/cache/CacheTest.java
@@ -1,6 +1,5 @@
 package no.stelar7.api.l4j8.tests.cache;
 
-import ch.qos.logback.classic.*;
 import no.stelar7.api.l4j8.basic.cache.impl.*;
 import no.stelar7.api.l4j8.basic.calling.DataCall;
 import no.stelar7.api.l4j8.basic.constants.api.*;
@@ -13,6 +12,7 @@ import no.stelar7.api.l4j8.pojo.summoner.Summoner;
 import no.stelar7.api.l4j8.tests.SecretFile;
 import org.junit.*;
 import org.junit.rules.Stopwatch;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
@@ -76,8 +76,7 @@ public class CacheTest
     @Test
     public void testCacheStuff() throws InterruptedException
     {
-        Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-        root.setLevel(Level.ALL);
+        Logger root = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         
         DataCall.setCacheProvider(fileCache);
         String id = new SpectatorBuilder().withPlatform(Platform.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();


### PR DESCRIPTION
Libraries should not package or be dependent on a logging framework, but
instead only use a logging facade (in this case SLF4J).
Using a logging framework forces the user of the API to also use it and
can cause issues, warnings and packaging errors down the line